### PR TITLE
Dockerfile: Updated timezone to be London instead of UTC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ COPY plugins.base.txt /usr/share/jenkins/ref/
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.base.txt
 COPY plugins.txt /usr/share/jenkins/ref/
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
+RUN rm /etc/localtime
+RUN ln -s /usr/share/zoneinfo/Europe/London /etc/localtime
 
 EXPOSE 8080
 VOLUME /opt/jenkins


### PR DESCRIPTION
Dockerfile: Updated timezone to be London instead of UTC